### PR TITLE
Entfernt unnötige Delegateinstanziierung

### DIFF
--- a/CRT-Logger/Controller.cs
+++ b/CRT-Logger/Controller.cs
@@ -14,10 +14,10 @@ namespace CRT_Logger
         public Controller(Gui gui)
         {
             this.gui = gui;
-            gui.testButtonClick += new Gui.testButtonClickHandler(OnTestButtonClick);
+            gui.testButtonClick += OnTestButtonClick;
 
             ticker = new Services.Ticker(1000);
-            ticker.tick += new Services.Ticker.tickHandler(OnTick);
+            ticker.tick += OnTick;
         }
 
         private void OnTestButtonClick(object o, EventArgs e)


### PR DESCRIPTION
Man braucht in diesen Abschnitten das new Gui.testButtonClickHandler nicht. Der Compiler macht aus der verkürtzten variante automatisch die längere, was diese unnötig macht.
Deswegen braucht man das auch nicht bei dem System.Timers.Timer
